### PR TITLE
[Feature] Implement `StrictValidator`, capable of applying rules to entire data array itself.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,14 @@
     "type": "library",
     "require": {
         "php": "^8.0",
-        "illuminate/validation": "^8.0"
+        "illuminate/validation": "^8.0",
+        "illuminate/support": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.3",
-        "phpstan/phpstan": "^1.5"
+        "phpstan/phpstan": "^1.5",
+        "laravel/framework": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/HyruleServiceProvider.php
+++ b/src/HyruleServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Square\Hyrule;
+
+use Illuminate\Contracts\Validation\Factory as FactoryContract;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Validation\Factory;
+use RuntimeException;
+use Square\Hyrule\Validator\StrictValidator;
+
+class HyruleServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        if (config('hyrule.use_strict_validator', false)) {
+            $this->extendValidatorFactory();
+        }
+    }
+
+    public function boot()
+    {
+        // No-op.
+    }
+
+    private function extendValidatorFactory()
+    {
+        $this->app->extend(FactoryContract::class, function (FactoryContract $factory) {
+            if (!$factory instanceof Factory) {
+                throw new RuntimeException(sprintf(
+                    'Expected bound instance for %s to be of type %s. Got %s.',
+                    FactoryContract::class,
+                    Factory::class,
+                    get_class($factory),
+                ));
+            }
+            $factory->resolver(function (...$args) {
+                return new StrictValidator(...$args);
+            });
+            return $factory;
+        });
+    }
+}

--- a/src/HyruleServiceProvider.php
+++ b/src/HyruleServiceProvider.php
@@ -16,7 +16,7 @@ class HyruleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->extendValidatorFactory(config('hyrule.strict_validator_class'));
+        $this->extendValidatorFactory(config('hyrule.use_strict_validator_class'));
     }
 
     /**
@@ -41,7 +41,7 @@ class HyruleServiceProvider extends ServiceProvider
 
         if (!is_a($className, Validator::class, true)) {
             throw new RuntimeException(sprintf(
-                'hyrule.strict_validator_class string value must be class that implements %s. Got %s.',
+                'hyrule.use_strict_validator_class string value must be class that implements %s. Got %s.',
                 Validator::class,
                 $className,
             ));

--- a/src/HyruleServiceProvider.php
+++ b/src/HyruleServiceProvider.php
@@ -11,11 +11,17 @@ use Square\Hyrule\Validator\StrictValidator;
 
 class HyruleServiceProvider extends ServiceProvider
 {
+    /**
+     * @return void
+     */
     public function register()
     {
         $this->extendValidatorFactory(config('hyrule.strict_validator_class'));
     }
 
+    /**
+     * @return void
+     */
     public function boot()
     {
         $this->publishes([

--- a/src/Rules/KnownPropertiesOnly.php
+++ b/src/Rules/KnownPropertiesOnly.php
@@ -42,7 +42,8 @@ class KnownPropertiesOnly implements Rule, ValidatorAwareRule
 
         $unknownProperties = array_diff($keys, $this->allowedProperties);
         foreach ($unknownProperties as $property) {
-            $this->validator->addFailure(sprintf('%s.%s', $attribute, $property), 'unknown_property', [
+            $errorProperty = empty($attribute) ? $property : sprintf('%s.%s', $attribute, $property);
+            $this->validator->addFailure($errorProperty, 'unknown_property', [
                 'property' => $property,
                 'allowed_properties' => $this->allowedProperties,
             ]);

--- a/src/Validator/StrictValidator.php
+++ b/src/Validator/StrictValidator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Square\Hyrule\Validator;
+
+use Illuminate\Validation\Validator;
+
+class StrictValidator extends Validator
+{
+    use ValidatesTopLevelRules;
+}

--- a/src/Validator/ValidatesTopLevelRules.php
+++ b/src/Validator/ValidatesTopLevelRules.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Square\Hyrule\Validator;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+trait ValidatesTopLevelRules
+{
+    /**
+     * Get the value od a given attribute. Interpret "" as top-level data.
+     * @param string $attribute
+     * @return mixed
+     */
+    protected function getValue($attribute)
+    {
+        assert($this instanceof Validator);
+        if ($attribute === '') {
+            return $this->data;
+        }
+        return parent::getValue($attribute);
+    }
+
+    /**
+     * Determine if the attribute is validatable. Allows "" attribute, which
+     * will be interpreted as top-level data.
+     *
+     * @param Rule|string $rule
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    protected function isValidatable($rule, $attribute, $value)
+    {
+        assert($this instanceof Validator);
+        if ($attribute === '') {
+            return true;
+        }
+        return parent::isValidatable($rule, $attribute, $value);
+    }
+}

--- a/src/config/hyrule.php
+++ b/src/config/hyrule.php
@@ -14,5 +14,5 @@ return [
      *     Square\Hyrule\Validator\ValidatesTopLevelRules
      * 2.) Anything else e.g. NULL/FALSE: Do not override existing behavior.
      */
-    'strict_validator_class' => Square\Hyrule\Validator\StrictValidator::class,
+    'use_strict_validator_class' => Square\Hyrule\Validator\StrictValidator::class,
 ];

--- a/src/config/hyrule.php
+++ b/src/config/hyrule.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    /**
+     * The framework will be configured to return instances of this class when building
+     * validators. This variant in particular is capable of evaluating top-level rules,
+     * keyed by the "" field e.g.
+     *
+     *  ["" => new ValidatesEntireDataRule(...)]
+     *
+     * Possible values:
+     *
+     * 1.) Class name of any Validator class that uses the
+     *     Square\Hyrule\Validator\ValidatesTopLevelRules
+     * 2.) Anything else e.g. NULL/FALSE: Do not override existing behavior.
+     */
+    'strict_validator_class' => Square\Hyrule\Validator\StrictValidator::class,
+];

--- a/tests/Validator/CustomValidator.php
+++ b/tests/Validator/CustomValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Square\Hyrule\Tests\Validator;
+
+use Illuminate\Validation\Validator;
+use Square\Hyrule\Validator\ValidatesTopLevelRules;
+
+class CustomValidator extends Validator
+{
+    use ValidatesTopLevelRules;
+}

--- a/tests/Validator/StrictValidatorTest.php
+++ b/tests/Validator/StrictValidatorTest.php
@@ -4,13 +4,14 @@ namespace Square\Hyrule\Tests\Validator;
 
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
+use Illuminate\Validation\Rule;
 use Monolog\Test\TestCase;
 use Square\Hyrule\Hyrule;
 use Square\Hyrule\Validator\StrictValidator;
 
 class StrictValidatorTest extends TestCase
 {
-    public function testUnknownTopLevelField()
+    public function testUnknownTopLevelField(): void
     {
         $builder = Hyrule::create()
             ->string('foo')->end()
@@ -34,6 +35,12 @@ class StrictValidatorTest extends TestCase
         ], $messages->get('baz'));
     }
 
+    /**
+     * @param array<string,mixed> $data
+     * @param array<string,mixed> $rules
+     * @param array<string,mixed> $messages
+     * @return StrictValidator
+     */
     protected function makeValidator(array $data, array $rules, array $messages): StrictValidator
     {
         return new StrictValidator(

--- a/tests/Validator/StrictValidatorTest.php
+++ b/tests/Validator/StrictValidatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Square\Hyrule\Tests\Validator;
+
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Monolog\Test\TestCase;
+use Square\Hyrule\Hyrule;
+use Square\Hyrule\Validator\StrictValidator;
+
+class StrictValidatorTest extends TestCase
+{
+    public function testUnknownTopLevelField()
+    {
+        $builder = Hyrule::create()
+            ->string('foo')->end()
+            ->string('bar')->end()
+        ->end();
+
+        $validator = $this->makeValidator(
+            [
+                'foo' => 'FOO',
+                'bar' => 'BAR',
+                'baz' => 'BAZ',
+            ],
+            $builder->build(),
+            [],
+        );
+
+        $this->assertFalse($validator->passes());
+        $messages = $validator->messages();
+        $this->assertEquals([
+            'validation.unknown_property',
+        ], $messages->get('baz'));
+    }
+
+    protected function makeValidator(array $data, array $rules, array $messages): StrictValidator
+    {
+        return new StrictValidator(
+            new Translator(new ArrayLoader(), 'en'),
+            $data,
+            $rules,
+            $messages,
+        );
+    }
+}

--- a/tests/Validator/ValidatorFactoryTest.php
+++ b/tests/Validator/ValidatorFactoryTest.php
@@ -13,12 +13,12 @@ use Square\Hyrule\Validator\StrictValidator;
 class ValidatorFactoryTest extends TestCase
 {
     /**
-     * @var Application|mixed
+     * @var Application
      */
     protected Application $app;
 
     /**
-     * @var Kernel|mixed
+     * @var Kernel
      */
     private Kernel $kernel;
 
@@ -28,7 +28,7 @@ class ValidatorFactoryTest extends TestCase
         $this->kernel = $this->app->make(Kernel::class);
     }
 
-    public function testCreatedValidatorWithEmptyValue()
+    public function testCreatedValidatorWithEmptyValue(): void
     {
         putenv('STRICT_VALIDATOR_CLASS=') ;
         $this->kernel->bootstrap();
@@ -38,7 +38,7 @@ class ValidatorFactoryTest extends TestCase
         $this->assertEquals(Validator::class, get_class($validator));
     }
 
-    public function testCreatedValidatorWithDefaultConfig()
+    public function testCreatedValidatorWithDefaultConfig(): void
     {
         $defaultConfig = require __DIR__ . '/../../src/config/hyrule.php';
         $this->assertEquals(StrictValidator::class, $defaultConfig['strict_validator_class']);
@@ -50,7 +50,7 @@ class ValidatorFactoryTest extends TestCase
         $this->assertEquals(StrictValidator::class, get_class($validator));
     }
 
-    public function testCreatedValidatorWithCustomValidator()
+    public function testCreatedValidatorWithCustomValidator(): void
     {
         putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', CustomValidator::class));
         $this->kernel->bootstrap();
@@ -60,7 +60,7 @@ class ValidatorFactoryTest extends TestCase
         $this->assertEquals(CustomValidator::class, get_class($validator));
     }
 
-    public function testIncompatibleClassInConfig()
+    public function testIncompatibleClassInConfig(): void
     {
         putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', Kernel::class));
         $this->expectException(RuntimeException::class);

--- a/tests/Validator/ValidatorFactoryTest.php
+++ b/tests/Validator/ValidatorFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Square\Hyrule\Tests\Validator;
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Foundation\Application;
+use Illuminate\Validation\Validator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Square\Hyrule\Validator\StrictValidator;
+
+class ValidatorFactoryTest extends TestCase
+{
+    /**
+     * @var Application|mixed
+     */
+    protected Application $app;
+
+    /**
+     * @var Kernel|mixed
+     */
+    private Kernel $kernel;
+
+    public function setUp(): void
+    {
+        $this->app = require __DIR__ . '/../app/bootstrap/app.php';
+        $this->kernel = $this->app->make(Kernel::class);
+    }
+
+    public function testCreatedValidatorWithEmptyValue()
+    {
+        putenv('STRICT_VALIDATOR_CLASS=') ;
+        $this->kernel->bootstrap();
+        $factory = $this->app->make(Factory::class);
+        $this->assertInstanceOf(Factory::class, $factory);
+        $validator = $factory->make([], [], []);
+        $this->assertEquals(Validator::class, get_class($validator));
+    }
+
+    public function testCreatedValidatorWithDefaultConfig()
+    {
+        $defaultConfig = require __DIR__ . '/../../src/config/hyrule.php';
+        $this->assertEquals(StrictValidator::class, $defaultConfig['strict_validator_class']);
+        putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', $defaultConfig['strict_validator_class']));
+        $this->kernel->bootstrap();
+        $factory = $this->app->make(Factory::class);
+        $this->assertInstanceOf(Factory::class, $factory);
+        $validator = $factory->make([], [], []);
+        $this->assertEquals(StrictValidator::class, get_class($validator));
+    }
+
+    public function testCreatedValidatorWithCustomValidator()
+    {
+        putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', CustomValidator::class));
+        $this->kernel->bootstrap();
+        $factory = $this->app->make(Factory::class);
+        $this->assertInstanceOf(Factory::class, $factory);
+        $validator = $factory->make([], [], []);
+        $this->assertEquals(CustomValidator::class, get_class($validator));
+    }
+
+    public function testIncompatibleClassInConfig()
+    {
+        putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', Kernel::class));
+        $this->expectException(RuntimeException::class);
+        $this->kernel->bootstrap();
+    }
+}

--- a/tests/Validator/ValidatorFactoryTest.php
+++ b/tests/Validator/ValidatorFactoryTest.php
@@ -41,8 +41,8 @@ class ValidatorFactoryTest extends TestCase
     public function testCreatedValidatorWithDefaultConfig(): void
     {
         $defaultConfig = require __DIR__ . '/../../src/config/hyrule.php';
-        $this->assertEquals(StrictValidator::class, $defaultConfig['strict_validator_class']);
-        putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', $defaultConfig['strict_validator_class']));
+        $this->assertEquals(StrictValidator::class, $defaultConfig['use_strict_validator_class']);
+        putenv(sprintf('STRICT_VALIDATOR_CLASS=%s', $defaultConfig['use_strict_validator_class']));
         $this->kernel->bootstrap();
         $factory = $this->app->make(Factory::class);
         $this->assertInstanceOf(Factory::class, $factory);

--- a/tests/app/bootstrap/app.php
+++ b/tests/app/bootstrap/app.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Create The Application
+|--------------------------------------------------------------------------
+|
+| The first thing we will do is create a new Laravel application instance
+| which serves as the "glue" for all the components of Laravel, and is
+| the IoC container for the system binding all of the various parts.
+|
+*/
+
+$app = new Illuminate\Foundation\Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+/*
+|--------------------------------------------------------------------------
+| Bind Important Interfaces
+|--------------------------------------------------------------------------
+|
+| Next, we need to bind some important interfaces into the container so
+| we will be able to resolve them when needed. The kernels serve the
+| incoming requests to this application from both the web and CLI.
+|
+*/
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    Illuminate\Foundation\Http\Kernel::class,
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    Illuminate\Foundation\Console\Kernel::class,
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    Illuminate\Foundation\Exceptions\Handler::class,
+);
+
+/*
+|--------------------------------------------------------------------------
+| Return The Application
+|--------------------------------------------------------------------------
+|
+| This script returns the application instance. The instance is given to
+| the calling script so we can separate the building of the instances
+| from the actual running of the application and sending responses.
+|
+*/
+
+return $app;

--- a/tests/app/bootstrap/cache/.gitignore
+++ b/tests/app/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/config/app.php
+++ b/tests/app/config/app.php
@@ -1,0 +1,201 @@
+<?php
+
+use Illuminate\Support\Facades\Facade;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to place the application's name in a notification or
+    | any other location as required by the application or its packages.
+    |
+    */
+
+    'name' => env('APP_NAME', 'Laravel'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Environment
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the "environment" your application is currently
+    | running in. This may determine how you prefer to configure various
+    | services the application utilizes. Set this in your ".env" file.
+    |
+    */
+
+    'env' => env('APP_ENV', 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => (bool) env('APP_DEBUG', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used by the console to properly generate URLs when using
+    | the Artisan command line tool. You should set this to the root of
+    | your application so that it is used when running Artisan tasks.
+    |
+    */
+
+    'url' => env('APP_URL', 'http://localhost'),
+
+    'asset_url' => env('ASSET_URL'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default timezone for your application, which
+    | will be used by the PHP date and date-time functions. We have gone
+    | ahead and set this to a sensible default for you out of the box.
+    |
+    */
+
+    'timezone' => 'UTC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application locale determines the default locale that will be used
+    | by the translation service provider. You are free to set this value
+    | to any of the locales which will be supported by the application.
+    |
+    */
+
+    'locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Fallback Locale
+    |--------------------------------------------------------------------------
+    |
+    | The fallback locale determines the locale to use when the current one
+    | is not available. You may change the value to correspond to any of
+    | the language folders that are provided through your application.
+    |
+    */
+
+    'fallback_locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Faker Locale
+    |--------------------------------------------------------------------------
+    |
+    | This locale will be used by the Faker PHP library when generating fake
+    | data for your database seeds. For example, this will be used to get
+    | localized telephone numbers, street address information and more.
+    |
+    */
+
+    'faker_locale' => 'en_US',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
+    |
+    */
+
+    'key' => env('APP_KEY'),
+
+    'cipher' => 'AES-256-CBC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maintenance Mode Driver
+    |--------------------------------------------------------------------------
+    |
+    | These configuration options determine the driver used to determine and
+    | manage Laravel's "maintenance mode" status. The "cache" driver will
+    | allow maintenance mode to be controlled across multiple machines.
+    |
+    | Supported drivers: "file", "cache"
+    |
+    */
+
+    'maintenance' => [
+        'driver' => 'file',
+        // 'store'  => 'redis',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Autoloaded Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded on the
+    | request to your application. Feel free to add your own services to
+    | this array to grant expanded functionality to your applications.
+    |
+    */
+
+    'providers' => [
+
+        /*
+         * Laravel Framework Service Providers...
+         */
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        Illuminate\Bus\BusServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
+        Illuminate\Cookie\CookieServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
+        Illuminate\Mail\MailServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
+        Illuminate\Pagination\PaginationServiceProvider::class,
+        Illuminate\Pipeline\PipelineServiceProvider::class,
+        Illuminate\Queue\QueueServiceProvider::class,
+        Illuminate\Redis\RedisServiceProvider::class,
+        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
+        Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Validation\ValidationServiceProvider::class,
+        Square\Hyrule\HyruleServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+
+        /*
+         * Package Service Providers...
+         */
+
+        /*
+         * Application Service Providers...
+         */
+//        App\Providers\AppServiceProvider::class,
+//        App\Providers\AuthServiceProvider::class,
+//        // App\Providers\BroadcastServiceProvider::class,
+//        App\Providers\EventServiceProvider::class,
+//        App\Providers\RouteServiceProvider::class,
+
+    ],
+
+];

--- a/tests/app/config/hyrule.php
+++ b/tests/app/config/hyrule.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    // Reads from env: tests will override this to assert various behavior.
     'strict_validator_class' => env('STRICT_VALIDATOR_CLASS'),
 ];
 

--- a/tests/app/config/hyrule.php
+++ b/tests/app/config/hyrule.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'strict_validator_class' => env('STRICT_VALIDATOR_CLASS'),
+];
+

--- a/tests/app/config/hyrule.php
+++ b/tests/app/config/hyrule.php
@@ -2,6 +2,6 @@
 
 return [
     // Reads from env: tests will override this to assert various behavior.
-    'strict_validator_class' => env('STRICT_VALIDATOR_CLASS'),
+    'use_strict_validator_class' => env('STRICT_VALIDATOR_CLASS'),
 ];
 

--- a/tests/app/storage/app/.gitignore
+++ b/tests/app/storage/app/.gitignore
@@ -1,0 +1,3 @@
+*
+!public/
+!.gitignore

--- a/tests/app/storage/app/public/.gitignore
+++ b/tests/app/storage/app/public/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/storage/framework/.gitignore
+++ b/tests/app/storage/framework/.gitignore
@@ -1,0 +1,9 @@
+compiled.php
+config.php
+down
+events.scanned.php
+maintenance.php
+routes.php
+routes.scanned.php
+schedule-*
+services.json

--- a/tests/app/storage/framework/cache/.gitignore
+++ b/tests/app/storage/framework/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!data/
+!.gitignore

--- a/tests/app/storage/framework/cache/data/.gitignore
+++ b/tests/app/storage/framework/cache/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/storage/framework/sessions/.gitignore
+++ b/tests/app/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/storage/framework/testing/.gitignore
+++ b/tests/app/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/storage/framework/views/.gitignore
+++ b/tests/app/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/app/storage/logs/.gitignore
+++ b/tests/app/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Introduces a service provider which configures the `Validator` factory to return instances of `Square\Hyrule\Validator\StrictValidator`.

I was hoping that this would be built-in behavior in Laravel already, but that PR was rejected: https://github.com/laravel/framework/pull/41962

In the meantime, the `ValidatesTopLevelRules` trait should bring this capability to any Validator class that uses it.

This will be the default behavior, but can be disabled by setting `hyrule.strict_validator_class` to a falsy value.