### PR TITLE
[Feature] Implement `FileNode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ $builder
             // etc.
 ```
 
+### File Uploads
+
+As of 2.3, Hyrule supports specifying rules for file uploads:
+
+```php
+$builder
+    ->file('attachment')
+        ->required()
+        ->mime('image', 'video', 'text')
+        ->end()
+    // etc.
+
+```
+
+See the following detailed guides on how to validate file uploads by file-type (MIME type), dimensions, etc.
+
+* [File Upload Validation - Images](./docs/file-upload-validation-images.md)
+* [File Upload Validation - Other MIME Types](./docs/file-upload-validation-mime-types.md)
 
 
 ## Rules API

--- a/docs/file-upload-validation-images.md
+++ b/docs/file-upload-validation-images.md
@@ -34,4 +34,4 @@ $builder = Hyrule::create()
     // ... 
 ```
 
-See [`File Upload Validation - MIME Types`] for a comprehensive guide on MIME-Type rules.
+See [File Upload Validation - MIME Types](./file-upload-validation-mime-types.md) for a comprehensive guide on MIME-Type rules.

--- a/docs/file-upload-validation-images.md
+++ b/docs/file-upload-validation-images.md
@@ -1,0 +1,37 @@
+## File Upload Validation - Images
+
+Here are a few examples for how you can validate image uploads.
+
+### Validate dimensions
+
+```php
+
+$builder = Hyrule::create()
+    ->file('avatar')
+        ->required()
+        ->image()   // Validates that upload is an image.
+        ->dimensions()  // Starts dimension constraints...
+            ->ratio(1)
+            ->maxWidth(1000)
+            ->end() // Ends dimension rule-set.
+        ->end() // Ends the "avatar" field.
+    // ... 
+
+```
+
+See [`Dimensions`](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Validation/Rules/Dimensions.php) class for all available constraints.
+
+### Only accept subset of image types
+
+```php
+$builder = Hyrule::create()
+    ->file('avatar')
+        ->required()
+        ->mimeType() // Starts MIME-type constriants...
+            ->image('jpeg', 'gif', 'png') // Only accept image/{jpeg,gif,png}
+            ->end() // End MIME-Type constraints.
+        ->end() // End the "avatar" field.
+    // ... 
+```
+
+See [`File Upload Validation - MIME Types`] for a comprehensive guide on MIME-Type rules.

--- a/docs/file-upload-validation-mime-types.md
+++ b/docs/file-upload-validation-mime-types.md
@@ -1,3 +1,41 @@
 ## File Upload Validation - MIME Types
 
-_TBD_
+It is considered best practice to validate the MIME type of uploaded files. Here are a few examples on how to do that with Hyrule:
+
+```php
+$builder = Hyrule::create()
+    ->file('attachment')
+        ->mimeType() // Starts MIME-Type contraints
+            /*
+             * All 5 top-level MIME type categories are supported
+             */
+            ->application('pdf') // Allows application/pdf
+            ->image('jpg', 'png', ...) // Variadic. Enumerate sub-types e.g. image/jpeg, image/png, etc.
+            ->video('mp4', 'webm')
+            ->multipart(...)
+            ->message(...)
+            ->end() // Ends MIME Type constraint.
+        ->end() // Ends "attachment" field
+        // ...
+```
+
+Use `->allow(...)` to enumerate specific specific MIME-types:
+
+```php
+$builder = Hyrule::create()
+    ->array('attachments')
+        ->between(1, 10)
+        ->each('file')
+            ->mimeType()
+                ->allow('application/pdf')
+                ->allow('image/jpg')
+                ->allow('image/png')
+                ->allow('image/svg')
+                ->allow('video/mp4')
+                // etc.
+                ->end()
+            ->end()
+        ->end()
+    // ...
+
+```

--- a/docs/file-upload-validation-mime-types.md
+++ b/docs/file-upload-validation-mime-types.md
@@ -1,0 +1,3 @@
+## File Upload Validation - MIME Types
+
+_TBD_

--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -10,6 +10,7 @@ use LogicException;
 use Square\Hyrule\Build\LazyRuleStringify;
 use Square\Hyrule\Path;
 use Square\Hyrule\PathExp;
+use Stringable;
 
 /**
  * @method $this|AbstractNode|ArrayNode|ScalarNode|ObjectNode required()
@@ -28,7 +29,7 @@ use Square\Hyrule\PathExp;
 abstract class AbstractNode
 {
     /**
-     * @var array|string[]|LazyRuleStringify[]|Rule[]
+     * @var array|string[]|LazyRuleStringify[]|Rule[]|Stringable
      */
     protected array $rules = [];
 
@@ -137,10 +138,10 @@ abstract class AbstractNode
     }
 
     /**
-     * @param string|Rule $rule
-     * @return $this|AbstractNode|ScalarNode|ObjectNode|ArrayNode
+     * @param string|Rule|Stringable $rule
+     * @return AbstractNode
      */
-    public function rule(string|Rule $rule): self
+    public function rule(string|Rule|Stringable $rule): self
     {
         $this->rules[] = $rule;
         return $this;
@@ -205,6 +206,8 @@ abstract class AbstractNode
                 $rule = (string) $rule->setNode($this)->stringify();
             } else if ($rule instanceof self) {
                 $rule = (string) (new Path($rule))->pathName();
+            } else if ($rule instanceof Stringable) {
+                $rule = $rule->__toString();
             }
             return $rule;
         }, $this->rules);

--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -29,7 +29,7 @@ use Stringable;
 abstract class AbstractNode
 {
     /**
-     * @var array|string[]|LazyRuleStringify[]|Rule[]|Stringable
+     * @var array|string[]|LazyRuleStringify[]|Rule[]|Stringable[]
      */
     protected array $rules = [];
 

--- a/src/Nodes/ArrayNode.php
+++ b/src/Nodes/ArrayNode.php
@@ -9,9 +9,6 @@ use Illuminate\Contracts\Validation\Rule;
 use InvalidArgumentException;
 use LogicException;
 
-/**
- * @property bool $allowUnknownProperties
- */
 class ArrayNode extends CompoundNode
 {
     /**
@@ -31,6 +28,7 @@ class ArrayNode extends CompoundNode
         'array' => ArrayNode::class,
         'object' => ObjectNode::class,
         'scalar' => ScalarNode::class,
+        'file' => FileNode::class,
     ];
 
     /**
@@ -45,7 +43,7 @@ class ArrayNode extends CompoundNode
 
     /**
      * @param string $type
-     * @return AbstractNode|ArrayNode|ObjectNode
+     * @return AbstractNode|ArrayNode|ObjectNode|FileNode
      */
     public function each(string $type): AbstractNode
     {

--- a/src/Nodes/FileNode.php
+++ b/src/Nodes/FileNode.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Square\Hyrule\Nodes;
+
+use Square\Hyrule\Rules\Dimensions;
+use Square\Hyrule\Rules\MIMEType;
+
+class FileNode extends AbstractNode
+{
+    protected ?Dimensions $dimensions;
+
+    protected ?MIMEType $mimeType;
+
+    /**
+     * @return Dimensions
+     */
+    public function dimensions(): Dimensions
+    {
+        if (!isset($this->dimensions)) {
+            // Create a new Dimensions rule object, push it to the rules array, and
+            // keep a reference so we can modify it when we need to in the future.
+            $this->rule($this->dimensions = new Dimensions($this));
+        }
+        return $this->dimensions;
+    }
+
+    /**
+     * @return $this
+     */
+    public function image(): FileNode
+    {
+        $this->rule('image');
+        return $this;
+    }
+
+    /**
+     * @return MIMEType
+     */
+    public function mimeType(): MIMEType
+    {
+        if (!isset($this->mimeType)) {
+            // Create a new MIMEType rule object, push it to the rules array, and
+            // keep a reference so we can modify it when we need to in the future.
+            $this->rule($this->mimeType = new MIMEType($this));
+        }
+        return $this->mimeType;
+    }
+}

--- a/src/Nodes/ObjectNode.php
+++ b/src/Nodes/ObjectNode.php
@@ -90,6 +90,15 @@ class ObjectNode extends CompoundNode
 
     /**
      * @param string $name
+     * @return FileNode
+     */
+    public function file(string $name): FileNode
+    {
+        return $this->registerNode(new FileNode($name, $this));
+    }
+
+    /**
+     * @param string $name
      * @return ObjectNode
      */
     public function object(string $name): ObjectNode
@@ -191,6 +200,18 @@ class ObjectNode extends CompoundNode
     public function arrayWith(string $name, callable $callable): self
     {
         $this->registerNode(new ArrayNode($name, $this))
+            ->with($callable);
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param callable $callable
+     * @return $this
+     */
+    public function fileWith(string $name, callable $callable): self
+    {
+        $this->registerNode(new FileNode($name, $this))
             ->with($callable);
         return $this;
     }

--- a/src/PHPStan/ArrayNodeEachDynamicReturnExtension.php
+++ b/src/PHPStan/ArrayNodeEachDynamicReturnExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Square\Hyrule\Nodes\ArrayNode;
 use Square\Hyrule\Nodes\BooleanNode;
+use Square\Hyrule\Nodes\FileNode;
 use Square\Hyrule\Nodes\FloatNode;
 use Square\Hyrule\Nodes\IntegerNode;
 use Square\Hyrule\Nodes\NumericNode;
@@ -65,6 +66,8 @@ class ArrayNodeEachDynamicReturnExtension implements DynamicMethodReturnTypeExte
                 return new ObjectType(NumericNode::class);
             case "boolean":
                 return new ObjectType(BooleanNode::class);
+            case "file":
+                return new ObjectType(FileNode::class);
             default:
                 return null;
         }

--- a/src/Rules/Dimensions.php
+++ b/src/Rules/Dimensions.php
@@ -14,7 +14,7 @@ class Dimensions extends DimensionsRule
 
     /**
      * @param FileNode $node
-     * @param array $constraints
+     * @param array<string,mixed> $constraints
      */
     public function __construct(FileNode $node, array $constraints = [])
     {

--- a/src/Rules/Dimensions.php
+++ b/src/Rules/Dimensions.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Square\Hyrule\Rules;
+
+use Illuminate\Validation\Rules\Dimensions as DimensionsRule;
+use Square\Hyrule\Nodes\FileNode;
+
+/**
+ * Extends the Laravel's built-in Dimensions helper and adds methods to support Hyrule's fluent API.
+ */
+class Dimensions extends DimensionsRule
+{
+    private FileNode $node;
+
+    /**
+     * @param FileNode $node
+     * @param array $constraints
+     */
+    public function __construct(FileNode $node, array $constraints = [])
+    {
+        $this->node = $node;
+        parent::__construct($constraints);
+    }
+
+    public function end(): FileNode
+    {
+        return $this->node;
+    }
+}

--- a/src/Rules/MIMEType.php
+++ b/src/Rules/MIMEType.php
@@ -124,7 +124,7 @@ class MIMEType
 
     /**
      * @param string $type
-     * @param array $subTypes
+     * @param array<string> $subTypes
      * @return $this
      */
     protected function typeAndSubtypes(string $type, array $subTypes): self

--- a/src/Rules/MIMEType.php
+++ b/src/Rules/MIMEType.php
@@ -2,7 +2,6 @@
 
 namespace Square\Hyrule\Rules;
 
-use Hoa\File\File;
 use Square\Hyrule\Nodes\FileNode;
 
 class MIMEType

--- a/src/Rules/MIMEType.php
+++ b/src/Rules/MIMEType.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Square\Hyrule\Rules;
+
+use Hoa\File\File;
+use Square\Hyrule\Nodes\FileNode;
+
+class MIMEType
+{
+    private FileNode $node;
+
+    /**
+     * @var string[]
+     */
+    protected array $mimeTypes = [];
+
+    /**
+     * @param FileNode $node
+     */
+    public function __construct(FileNode $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * @return $this
+     */
+    public function pdf(): self
+    {
+        return $this->allow('application/pdf');
+    }
+
+    /**
+     * @return $this
+     */
+    public function json(): self
+    {
+        return $this->allow('application/json');
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function text(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('text', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function image(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('image', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function audio(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('audio', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function video(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('video', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function application(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('application', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function multipart(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('multipart', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $subType
+     * @param string ...$subTypes
+     * @return $this
+     */
+    public function message(string $subType, string ...$subTypes): self
+    {
+        array_unshift($subTypes, $subType);
+        $this->typeAndSubtypes('message', $subTypes);
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @param array $subTypes
+     * @return $this
+     */
+    protected function typeAndSubtypes(string $type, array $subTypes): self
+    {
+        foreach ($subTypes as $subType) {
+            $this->allow(sprintf('%s/%s', $type, $subType));
+        }
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return $this
+     */
+    public function allow(string $type): self
+    {
+        $this->mimeTypes[$type] = $type;
+        return $this;
+    }
+
+    public function __toString()
+    {
+        if (empty($this->mimeTypes)) {
+            return '';
+        }
+
+        return sprintf('mimetypes:%s', implode(',', array_values($this->mimeTypes)));
+    }
+
+    /**
+     * @return FileNode
+     */
+    public function end(): FileNode
+    {
+        return $this->node;
+    }
+}

--- a/tests/ArrayNodeTest.php
+++ b/tests/ArrayNodeTest.php
@@ -3,6 +3,7 @@
 namespace Square\Hyrule\Tests;
 
 use Generator;
+use Illuminate\Http\UploadedFile;
 use Square\Hyrule\Nodes\ArrayNode;
 
 class ArrayNodeTest extends NodeTestAbstract
@@ -80,6 +81,21 @@ class ArrayNodeTest extends NodeTestAbstract
                         ->each('integer')->end();
             }
         ];
+
+        yield 'array of images' => [
+            [
+                UploadedFile::fake()->image('foo.jpeg'),
+                UploadedFile::fake()->image('foo.jpg'),
+                UploadedFile::fake()->image('foo.png'),
+                UploadedFile::fake()->image('foo.gif'),
+                UploadedFile::fake()->image('foo.svg'),
+                UploadedFile::fake()->image('foo.bmp'),
+            ],
+            static function(ArrayNode $node) {
+                $node->each('file')
+                    ->image();
+            }
+        ];
     }
 
     /**
@@ -137,6 +153,20 @@ class ArrayNodeTest extends NodeTestAbstract
                 $node->each('array')
                         ->each('integer')->end()
                         ->min(1);
+            }
+        ];
+
+        yield 'array of files' => [
+            [
+                UploadedFile::fake()->create('foo.pdf', 0, 'application/pdf'),
+                UploadedFile::fake()->image('foo.jpeg'),
+                UploadedFile::fake()->create('foo.json', 0, 'application/json'),
+            ],
+            static function(ArrayNode $node) {
+                $node->each('file')
+                    ->mimeType()
+                        ->application('pdf')
+                        ->image('jpeg');
             }
         ];
     }

--- a/tests/FileNodeTest.php
+++ b/tests/FileNodeTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Square\Hyrule\Tests;
+
+use Generator;
+use Hoa\File\File;
+use Illuminate\Http\UploadedFile;
+use Square\Hyrule\Hyrule;
+use Square\Hyrule\Nodes\FileNode;
+use Square\Hyrule\Rules\Dimensions;
+use Square\Hyrule\Rules\MIMEType;
+
+class FileNodeTest extends NodeTestAbstract
+{
+    protected function getBuilderMethodName(): string
+    {
+        return 'file';
+    }
+
+    public function dataValid()
+    {
+        yield 'image' => [
+            UploadedFile::fake()->image('foo.jpg'),
+            static function(FileNode $node) {
+                return $node->image();
+            },
+        ];
+
+        yield 'image: matches max width & height' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 600),
+            static function(FileNode $node) {
+                $node->dimensions()->maxWidth(800)->maxHeight(600);
+            },
+        ];
+
+        yield 'image: smaller than max width & height' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 600),
+            static function(FileNode $node) {
+                $node->dimensions()->maxWidth(1000)->maxHeight(1000);
+            }
+        ];
+
+        yield 'image: exact dimensions' => [
+            UploadedFile::fake()->image('foo.jpg', 1024, 768),
+            static function(FileNode $node) {
+                $node->dimensions()->width(1024)->height(768);
+            },
+        ];
+
+        yield 'image: ratio' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 800),
+            static function(FileNode $node) {
+                $node->dimensions()->ratio(1);
+            }
+        ];
+
+        yield 'mime-type: pdf' => [
+            UploadedFile::fake()->create('foo.pdf', 0, 'application/pdf'),
+            static function(FileNode $node) {
+                $node->mimeType()->pdf();
+            }
+        ];
+
+        yield 'mime-type: json' => [
+            UploadedFile::fake()->create('foo.json', 0, 'application/json'),
+            static function(FileNode $node) {
+                $node->mimeType()->json();
+            }
+        ];
+
+        yield 'mime-type: text/plain' => [
+            UploadedFile::fake()->create('foo.txt', 0, 'text/plain'),
+            static function(FileNode $node) {
+                $node->mimeType()->text('plain');
+            }
+        ];
+
+        yield 'mime-type explicit: text/plain' => [
+            UploadedFile::fake()->create('foo.txt', 0, 'text/plain'),
+            static function(FileNode $node) {
+                $node->mimeType()->allow('text/plain');
+            },
+        ];
+    }
+    public function dataInvalid()
+    {
+        yield 'image' => [
+            UploadedFile::fake()->create('foo.txt'),
+            static function(FileNode $node) {
+                return $node->image();
+            },
+        ];
+
+        yield 'image: too large' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 600),
+            static function(FileNode $node) {
+                $node->dimensions()->maxWidth(500)->maxHeight(600);
+            },
+        ];
+
+        yield 'image: too small' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 600),
+            static function(FileNode $node) {
+                $node->dimensions()->minHeight(1000)->minWidth(1000);
+            }
+        ];
+
+        yield 'image: does not match dimensions' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 600),
+            static function(FileNode $node) {
+                $node->dimensions()->width(1024)->height(768);
+            },
+        ];
+
+        yield 'image: does not match ratio' => [
+            UploadedFile::fake()->image('foo.jpg', 800, 800),
+            static function(FileNode $node) {
+                $node->dimensions()->ratio(0.5);
+            }
+        ];
+
+        yield 'mime-type: not pdf' => [
+            UploadedFile::fake()->create('foo.txt'),
+            static function(FileNode $node) {
+                $node->mimeType()->pdf();
+            }
+        ];
+
+        yield 'mime-type: not json' => [
+            UploadedFile::fake()->create('foo.pdf'),
+            static function(FileNode $node) {
+                $node->mimeType()->json();
+            }
+        ];
+    }
+
+    protected function getNodeClassName(): string
+    {
+        return FileNode::class;
+    }
+
+    protected function defaultRules(): array
+    {
+        return [];
+    }
+
+    public function testDimensionsFluentAPI()
+    {
+        $file = Hyrule::create()->file('file');
+        $dimensions = $file->dimensions();
+        $this->assertInstanceOf(Dimensions::class, $dimensions);
+        $this->assertSame($dimensions, $file->dimensions());
+        $this->assertSame($file, $dimensions->end());
+    }
+
+    public function testMIMETypeFluentAPI()
+    {
+        $file = Hyrule::create()->file('file');
+        $mime = $file->mimeType();
+        $this->assertInstanceOf(MIMEType::class, $mime);
+        $this->assertSame($mime, $file->mimeType());
+        $this->assertSame($file, $mime->end());
+    }
+
+    /**
+     * @param array $expectedRules
+     * @param callable $callback
+     * @dataProvider dataBuiltRules
+     * @return void
+     */
+    public function testBuiltRules(array $expectedRules, callable $callback)
+    {
+        $file = Hyrule::create()->file('file');
+        $callback($file);
+        $this->assertEquals($expectedRules, $file->build()['file']);
+    }
+
+    /**
+     * @return Generator
+     */
+    public function dataBuiltRules(): Generator
+    {
+        yield 'dimensions: max width & height' => [
+            ['dimensions:max_width=100,max_height=100'],
+            static function(FileNode $node) {
+                $node->dimensions()->maxWidth(100)->maxHeight(100);
+            },
+        ];
+
+        yield 'dimensions: ratio' => [
+            ['dimensions:ratio=0.5'],
+            static function(FileNode $node) {
+                $node->dimensions()->ratio(0.5);
+            },
+        ];
+
+        yield 'mime-type: allow multiple' => [
+            ['mimetypes:text/plain,application/json,image/jpeg'],
+            static function(FileNode $node) {
+                $node->mimeType()
+                    ->allow('text/plain')
+                    ->allow('application/json')
+                    ->allow('image/jpeg');
+            },
+        ];
+
+        yield 'mime-type: via top-level type method' => [
+            ['mimetypes:text/plain,application/json,application/pdf,image/jpeg,image/png,video/webm,video/mp4'],
+            static function(FileNode $node) {
+                $node->mimeType()
+                    ->text('plain')
+                    ->application('json', 'pdf')
+                    ->image('jpeg', 'png')
+                    ->video('webm', 'mp4');
+            },
+        ];
+
+        yield 'mime-type: de-duped' => [
+            ['mimetypes:text/plain,application/json,application/pdf'],
+            static function(FileNode $node) {
+                $node->mimeType()
+                    ->text('plain')
+                    ->application('json', 'pdf')
+                    ->application('pdf', 'json')
+                    ->allow('application/json')
+                    ->allow('application/pdf');
+            },
+        ];
+    }
+}

--- a/tests/FileNodeTest.php
+++ b/tests/FileNodeTest.php
@@ -144,7 +144,7 @@ class FileNodeTest extends NodeTestAbstract
         return [];
     }
 
-    public function testDimensionsFluentAPI()
+    public function testDimensionsFluentAPI(): void
     {
         $file = Hyrule::create()->file('file');
         $dimensions = $file->dimensions();
@@ -153,7 +153,7 @@ class FileNodeTest extends NodeTestAbstract
         $this->assertSame($file, $dimensions->end());
     }
 
-    public function testMIMETypeFluentAPI()
+    public function testMIMETypeFluentAPI(): void
     {
         $file = Hyrule::create()->file('file');
         $mime = $file->mimeType();
@@ -163,12 +163,12 @@ class FileNodeTest extends NodeTestAbstract
     }
 
     /**
-     * @param array $expectedRules
+     * @param array<mixed> $expectedRules
      * @param callable $callback
      * @dataProvider dataBuiltRules
      * @return void
      */
-    public function testBuiltRules(array $expectedRules, callable $callback)
+    public function testBuiltRules(array $expectedRules, callable $callback): void
     {
         $file = Hyrule::create()->file('file');
         $callback($file);


### PR DESCRIPTION
Addresses https://github.com/square/laravel-hyrule/issues/7

### Example 1: Images

```php
$builder = Hyrule::create()
    ->file('avatar')
       ->image()
       ->dimensions()
           ->ratio(1)
           ->maxWidth(1000)
           ->end()
       ->end()
    ->string('username')
       // etc.

```

### Example 2: Other MIME types

```php
$builder = Hyrule::create()
    ->file('scan')
       ->mimeType()
           ->allow('application/pdf')
           ->image('jpg', 'png') // allows image/jpg & image/png
       ->end()
    ->string('username')
       // etc.

```

### Example 3: Array of files

```php
$builder = Hyrule::create()
    ->array('attachments')
       ->between(1, 10)
       ->each('file')
          ->mimeType()
            ->allow('application/pdf')
            ->image('jpg', 'png') // allows image/jpg & image/png
            ->text('plain', 'html') // allows text/plain & text/html
            ->video('mp4') // allows video/mp4
            ->end()
        ->end()
      ->end()
    ->string('username')
       // etc.

```

* [x] Node implementation
* [x] Tests
* [x] Static analysis
* [x] Documentation