### PR TITLE
Expand `@return` annotation of AbstractNode#end() to help auto-complete w/o `@mixin` support

### DIFF
--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -56,7 +56,7 @@ abstract class AbstractNode
     }
 
     /**
-     * @return CompoundNode
+     * @return CompoundNode|ObjectNode|ArrayNode
      */
     public function end(): CompoundNode
     {


### PR DESCRIPTION
Apparently VSCode's intellisense cannot auto-complete well because it cannot not understand `@mixin`, even with the relevant PHP plugins. See https://github.com/square/laravel-hyrule/issues/6

This should help.