### PR TITLE
Improve rule normalization

### DIFF
--- a/src/Build/LazyRuleStringify.php
+++ b/src/Build/LazyRuleStringify.php
@@ -98,9 +98,14 @@ class LazyRuleStringify
                     return $value;
                     break;
                 }
-                throw new InvalidArgumentException('Objects must implement Stringable if used as arguments to string-based rules.');
+                throw new InvalidArgumentException(
+                    'Objects must implement Stringable if used as arguments to string-based rules.',
+                );
             default:
-                throw new InvalidArgumentException(sprintf('Cannot use %s as argument to string-based rules.', gettype($v)));
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot use %s as argument to string-based rules.',
+                    gettype($value),
+                ));
         }
     }
 }

--- a/src/Build/LazyRuleStringify.php
+++ b/src/Build/LazyRuleStringify.php
@@ -89,14 +89,15 @@ class LazyRuleStringify
                 return $value ? 'true' : 'false';
             case 'NULL':
                 return 'NULL';
-                break;
             case 'array':
                 throw new InvalidArgumentException('Cannot use arrays as argument to string-based rules.');
             case 'object':
                 if ($value instanceof Stringable) {
-                    /** If the value is Stringable, don't convert to string yet. */
+                    /*
+                     *  If the value is Stringable, don't convert to string yet. Let's leave it to consuming
+                     *  code to convert it to string at the right time e.g. last possible minute.
+                     *  */
                     return $value;
-                    break;
                 }
                 throw new InvalidArgumentException(
                     'Objects must implement Stringable if used as arguments to string-based rules.',

--- a/src/Build/LazyRuleStringify.php
+++ b/src/Build/LazyRuleStringify.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Square\Hyrule\Build;
 
+use InvalidArgumentException;
 use RuntimeException;
 use Square\Hyrule\Nodes\AbstractNode;
 use Square\Hyrule\Path;
 use Square\Hyrule\PathExp;
+use Stringable;
 
 /**
  * Understands how to construct rule specs when a PathExp instance is present among the arg list.
@@ -66,8 +68,39 @@ class LazyRuleStringify
             if ($arg instanceof AbstractNode) {
                 $arg = new Path($arg);
             }
-            $args[] = (string) $arg;
+            $args[] = (string) self::normalizeRuleArgumentValue($arg);
         }
         return sprintf('%s:%s', $this->ruleName, implode(',', $args));
+    }
+
+    /**
+     * @param mixed $value
+     * @return string|Stringable
+     */
+    public static function normalizeRuleArgumentValue(mixed $value): Stringable|string
+    {
+        switch (gettype($value)) {
+            case 'string':
+                return $value;
+            case 'double':
+            case 'integer':
+                return (string) $value;
+            case 'boolean':
+                return $value ? 'true' : 'false';
+            case 'NULL':
+                return 'NULL';
+                break;
+            case 'array':
+                throw new InvalidArgumentException('Cannot use arrays as argument to string-based rules.');
+            case 'object':
+                if ($value instanceof Stringable) {
+                    /** If the value is Stringable, don't convert to string yet. */
+                    return $value;
+                    break;
+                }
+                throw new InvalidArgumentException('Objects must implement Stringable if used as arguments to string-based rules.');
+            default:
+                throw new InvalidArgumentException(sprintf('Cannot use %s as argument to string-based rules.', gettype($v)));
+        }
     }
 }

--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -6,6 +6,7 @@ namespace Square\Hyrule\Nodes;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use LogicException;
 use Square\Hyrule\Build\LazyRuleStringify;
 use Square\Hyrule\Path;
@@ -93,11 +94,12 @@ abstract class AbstractNode
 
     /**
      * @param string|PathExp|AbstractNode $path
-     * @param string $value
+     * @param mixed $value
      * @return $this
      */
-    public function requiredIf(string|PathExp|AbstractNode $path, string $value): self
+    public function requiredIf(string|PathExp|AbstractNode $path, mixed $value): self
     {
+        $value = LazyRuleStringify::normalizeRuleArgumentValue($value);
         if ($path instanceof PathExp || $path instanceof self) {
             $rule = new LazyRuleStringify('required_if', [$path, $value]);
         } else {
@@ -185,6 +187,7 @@ abstract class AbstractNode
         }
 
         if (!$rule instanceof LazyRuleStringify) {
+            $arguments = array_map('\Square\Hyrule\Build\LazyRuleStringify::normalizeRuleArgumentValue', $arguments);
             $rule = sprintf('%s:%s', $methodName, implode(',', $arguments));
         }
 

--- a/tests/BuilderTypedTest.php
+++ b/tests/BuilderTypedTest.php
@@ -197,7 +197,7 @@ class BuilderTypedTest extends TestCase
         ], $builder->build());
     }
 
-    public function testRequiredIfBooleans()
+    public function testRequiredIfBooleans(): void
     {
         $builder = Hyrule::create()
             ->boolean('include_title')

--- a/tests/BuilderTypedTest.php
+++ b/tests/BuilderTypedTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Square\Hyrule\Tests;
 
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
 use PHPUnit\Framework\TestCase;
 use Square\Hyrule\Hyrule;
 use Square\Hyrule\Nodes\ArrayNode;
@@ -192,5 +195,25 @@ class BuilderTypedTest extends TestCase
             'bar.baz' => [new KnownPropertiesOnly(['foo'])],
             'bar.baz.foo' => ['integer', 'required_without:bar.foo'],
         ], $builder->build());
+    }
+
+    public function testRequiredIfBooleans()
+    {
+        $builder = Hyrule::create()
+            ->boolean('include_title')
+                ->end()
+            ->string('title')
+                ->requiredIf('include_title', true)
+                ->end()
+            ->end();
+
+        $rules = $builder->build();
+
+        $factory = new Factory(new Translator(new ArrayLoader(), 'en'));
+        $validator = $factory->make([
+            'include_title' => true,
+        ], $rules);
+
+        $this->assertFalse($validator->passes());
     }
 }


### PR DESCRIPTION
Take `AbstractNode#requiredIf`:

In order to properly validate an optionally required field based on another boolean field, you'd need to do something like this:

```php
$builder = Hyrule::create()
    ->boolean('needs_verification')
       ->end()
    ->file('proof')
       ->requiredIf('needs_verification', '1')
       ->end()
    ->end();
```

But that doesn't work correctly. This does:

```php
$builder = Hyrule::create()
    ->boolean('needs_verification')
       ->end()
    ->file('proof')
       ->requiredIf('needs_verification', 'true') // <- Must use "true"
       ->end()
    ->end();
```

But ideally, it should just allow using a true boolean value:

```php
$builder = Hyrule::create()
    ->boolean('needs_verification')
       ->end()
    ->file('proof')
       ->requiredIf('needs_verification', true) // <- Makes the most sense.
       ->end()
    ->end();
```

This PR loosens up the type requirements for `requiredIf`. It also brings proper normalization of `true|false => "true"|"false"` etc to other places e.g.

```php
    ->anotherRule(false, null)
    // Before: another_rule:0,
    // Now: another_rule:false,NULL
```