### PR TITLE
Setting CI running in PR trigger in any branch

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 permissions:
   contents: read


### PR DESCRIPTION
# Changed log

- I think it should let CI running about PR trigger can run any of branches because it's easy for same contributor to create two or more PRs at same time.