### PR TITLE
refactor: consolidated lazy rule-building logic into one place

### DIFF
--- a/src/Nodes/AbstractNode.php
+++ b/src/Nodes/AbstractNode.php
@@ -98,13 +98,25 @@ abstract class AbstractNode
      */
     public function requiredIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('required_if', [$path, $value]);
-        } else {
-            $rule = sprintf('required_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('required_if', [$path, $value]);
+    }
+
+    /**
+     * @param string|PathExp|AbstractNode $path
+     * @return $this
+     */
+    public function requiredIfAccepted(string|PathExp|AbstractNode $path): self
+    {
+        return $this->buildAndAddRule('required_if_accepted', [$path]);
+    }
+
+    /**
+     * @param string|PathExp|AbstractNode $path
+     * @return $this
+     */
+    public function requiredIfDeclined(string|PathExp|AbstractNode $path): self
+    {
+        return $this->buildAndAddRule('required_if_declined', [$path]);
     }
 
     /**
@@ -114,13 +126,7 @@ abstract class AbstractNode
      */
     public function requiredUnless(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('required_unless', [$path, $value]);
-        } else {
-            $rule = sprintf('required_unless:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('required_unless', [$path, $value]);
     }
 
     /**
@@ -129,13 +135,7 @@ abstract class AbstractNode
      */
     public function requiredWithout(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('required_without', [$path]);
-        } else {
-            $rule = sprintf('required_without:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('required_without', [$path]);
     }
 
     /**
@@ -144,13 +144,7 @@ abstract class AbstractNode
      */
     public function requiredWith(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('required_with', [$path]);
-        } else {
-            $rule = sprintf('required_with:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('required_with', [$path]);
     }
 
     /**
@@ -160,13 +154,7 @@ abstract class AbstractNode
      */
     public function declinedIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('declined_if', [$path, $value]);
-        } else {
-            $rule = sprintf('declined_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('declined_if', [$path, $value]);
     }
 
     /**
@@ -176,13 +164,7 @@ abstract class AbstractNode
      */
     public function missingIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('missing_if', [$path, $value]);
-        } else {
-            $rule = sprintf('missing_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('missing_if', [$path, $value]);
     }
 
     /**
@@ -192,13 +174,7 @@ abstract class AbstractNode
      */
     public function acceptedIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('accepted_if', [$path, $value]);
-        } else {
-            $rule = sprintf('accepted_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('accepted_if', [$path, $value]);
     }
 
     /**
@@ -208,13 +184,7 @@ abstract class AbstractNode
      */
     public function excludeIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('exclude_if', [$path, $value]);
-        } else {
-            $rule = sprintf('exclude_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('exclude_if', [$path, $value]);
     }
 
     /**
@@ -224,13 +194,7 @@ abstract class AbstractNode
      */
     public function excludeUnless(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('exclude_unless', [$path, $value]);
-        } else {
-            $rule = sprintf('exclude_unless:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('exclude_unless', [$path, $value]);
     }
 
     /**
@@ -239,13 +203,7 @@ abstract class AbstractNode
      */
     public function excludeWith(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('exclude_with', [$path]);
-        } else {
-            $rule = sprintf('exclude_with:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('exclude_with', [$path]);
     }
 
 
@@ -255,13 +213,7 @@ abstract class AbstractNode
      */
     public function excludeWithout(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('exclude_without', [$path]);
-        } else {
-            $rule = sprintf('exclude_without:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('exclude_without', [$path]);
     }
 
     /**
@@ -271,13 +223,7 @@ abstract class AbstractNode
      */
     public function prohibitedIf(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('prohibited_if', [$path, $value]);
-        } else {
-            $rule = sprintf('prohibited_if:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('prohibited_if', [$path, $value]);
     }
 
     /**
@@ -287,13 +233,7 @@ abstract class AbstractNode
      */
     public function prohibitedUnless(string|PathExp|AbstractNode $path, string $value): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('prohibited_unless', [$path, $value]);
-        } else {
-            $rule = sprintf('prohibited_unless:%s,%s', $path, $value);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('prohibited_unless', [$path, $value]);
     }
 
     /**
@@ -302,13 +242,7 @@ abstract class AbstractNode
      */
     public function prohibits(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('prohibits', [$path]);
-        } else {
-            $rule = sprintf('prohibits:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('prohibits', [$path]);
     }
 
     /**
@@ -317,13 +251,7 @@ abstract class AbstractNode
      */
     public function same(string|PathExp|AbstractNode $path): self
     {
-        if ($path instanceof PathExp || $path instanceof self) {
-            $rule = new LazyRuleStringify('same', [$path]);
-        } else {
-            $rule = sprintf('same:%s', $path);
-        }
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule('same', [$path]);
     }
 
 
@@ -362,24 +290,7 @@ abstract class AbstractNode
             return $this;
         }
 
-        $rule = $methodName;
-
-        /**
-         * Lets look for an instance of PathExp. If it exists, we'll wrap the rule in LazyRuleStringify.
-         */
-        foreach ($arguments as $arg) {
-            if ($arg instanceof PathExp || $arg instanceof self) {
-                $rule = new LazyRuleStringify($ruleName, $arguments);
-                break;
-            }
-        }
-
-        if (!$rule instanceof LazyRuleStringify) {
-            $rule = sprintf('%s:%s', $ruleName, implode(',', $arguments));
-        }
-
-        $this->rules[] = $rule;
-        return $this;
+        return $this->buildAndAddRule($ruleName, $arguments);
     }
 
     /**
@@ -415,4 +326,46 @@ abstract class AbstractNode
         $var = $this;
         return $this;
     }
+
+    /**
+     * Creates a rule string if all arguments are string. If an argument in a PathExp or a node, wrap in a rule object
+     * that lazily resolves the path strings on build.
+     *
+     * @param string $ruleName
+     * @param array<int,string|AbstractNode|PathExp> $ruleArguments
+     * @return LazyRuleStringify|string
+     */
+    protected static function buildRule(string $ruleName, array $ruleArguments): LazyRuleStringify|string
+    {
+        if (count($ruleArguments) === 0) {
+            return $ruleName;
+        }
+        foreach ($ruleArguments as $argument) {
+            if ($argument instanceof PathExp || $argument instanceof self) {
+                /**
+                 * We'll wrap the rule in LazyRuleStringify if we find a PathExp or a node
+                 */
+                return new LazyRuleStringify($ruleName, $ruleArguments);
+            }
+        }
+
+        // We are here because we didn't find any argument that should be lazily resolved.
+        // Let's treat them all as strings now.
+        // @phpstan-ignore-next-line
+        return sprintf('%s:%s', $ruleName, implode(',', $ruleArguments));
+    }
+
+    /**
+     * Build a rule via static::buildRule and add it to the rules list.
+     *
+     * @param string $ruleName
+     * @param array<int,string|AbstractNode|PathExp> $arguments
+     * @return $this
+     */
+    protected function buildAndAddRule(string $ruleName, array $arguments): self
+    {
+        $this->rules[] = static::buildRule($ruleName, $arguments);
+        return $this;
+    }
+
 }

--- a/tests/AbstractNodeTest.php
+++ b/tests/AbstractNodeTest.php
@@ -422,4 +422,45 @@ class AbstractNodeTest extends TestCase
             'prohibited_if:foo,baz',
         ];
     }
+
+    /**
+     * @param mixed $path
+     * @param string $expected
+     * @return void
+     * @dataProvider dataRequiredIfDeclined
+     */
+    public function testRequiredIfDeclined(mixed $path, string $expected)
+    {
+        $node = Hyrule::create()
+            ->object('foo')
+            ->string('bar')
+            ->requiredIfDeclined($path)
+            ->end()
+            ->end();
+        $rules = $node->build();
+        $this->assertEquals($expected, $rules['foo.bar'][1]);
+    }
+
+    public static function dataRequiredIfDeclined(): Generator
+    {
+        yield 'string path' => [
+            'foo.bar',
+            'required_if_declined:foo.bar',
+        ];
+
+        yield 'node path' => [
+            Hyrule::create()->string('boom'),
+            'required_if_declined:boom',
+        ];
+
+        yield 'nested node path' => [
+            Hyrule::create()->object('foo')->string('bar'),
+            'required_if_declined:foo.bar',
+        ];
+
+        yield 'path expression' => [
+            Hyrule::pathExp()->parent(),
+            'required_if_declined:foo',
+        ];
+    }
 }

--- a/tests/RuleBuildingTest.php
+++ b/tests/RuleBuildingTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Square\Hyrule\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Square\Hyrule\Build\LazyRuleStringify;
+use Square\Hyrule\Hyrule;
+use Square\Hyrule\Nodes\AbstractNode;
+use Stringable;
+
+class RuleBuildingTest extends TestCase
+{
+    protected AbstractNode $node;
+
+    public function setUp(): void
+    {
+        $this->node = new class ('test') extends AbstractNode {
+            public static function testBuildRule() {
+                return self::buildRule(...func_get_args());
+            }
+        };
+    }
+
+    /**
+     * @param string $ruleName
+     * @param array $arguments
+     * @param string $expected
+     * @param bool $lazy
+     * @dataProvider dataBuildRule
+     * @return void
+     */
+    public function testBuildRule(string $ruleName, array $arguments, string $expected)
+    {
+        $rule = $this->node::testBuildRule($ruleName, $arguments);
+        $this->assertIsString($rule);
+        $this->assertEquals($expected, (string) $rule);
+    }
+
+    /**
+     * @param string $ruleName
+     * @param array $arguments
+     * @param string $expected
+     * @dataProvider dataBuildLazyRule
+     * @return void
+     */
+    public function testBuildLazyRule(string $ruleName, array $arguments, AbstractNode $node, string $expected)
+    {
+        $rule = $this->node::testBuildRule($ruleName, $arguments);
+        $this->assertInstanceOf(LazyRuleStringify::class, $rule);
+        $rule->setNode($node);
+        $this->assertEquals($expected, $rule->stringify());
+    }
+
+    public function dataBuildRule()
+    {
+        yield 'string' => [
+            'rule_name',
+            ['foo'],
+            'rule_name:foo',
+            false,
+        ];
+
+        yield 'strings' => [
+            'rule_name',
+            ['foo', 'bar'],
+            'rule_name:foo,bar',
+            false,
+        ];
+
+        yield 'no args' => [
+            'rule_name',
+            [],
+            'rule_name',
+            false,
+        ];
+
+        yield 'stringable' => [
+            'rule_name',
+            [self::stringable('foo')],
+            'rule_name:foo',
+            false,
+        ];
+
+        yield 'many stringables' => [
+            'rule_name',
+            [self::stringable('foo'), self::stringable('bar'), self::stringable('baz')],
+            'rule_name:foo,bar,baz',
+            false,
+        ];
+
+        yield 'some stringables' => [
+            'rule_name',
+            [self::stringable('foo'), 'bar', self::stringable('baz')],
+            'rule_name:foo,bar,baz',
+            false,
+        ];
+
+        yield 'some stringables later in list' => [
+            'rule_name',
+            ['foo', 'bar', self::stringable('baz')],
+            'rule_name:foo,bar,baz',
+            false,
+        ];
+    }
+
+    protected static function stringable(string $value): Stringable
+    {
+        return new class($value) implements Stringable {
+            public function __construct(private readonly string $value)
+            { }
+
+            public function __toString()
+            {
+                return $this->value;
+            }
+        };
+    }
+
+    public function dataBuildLazyRule()
+    {
+        yield 'node' =>  [
+            'rule_name',
+            [Hyrule::create()->object('name')->string('first')],
+            Hyrule::create(),
+            'rule_name:name.first',
+        ];
+
+        yield 'many nodes' =>  [
+            'rule_name',
+            [Hyrule::create()->object('name')->string('first'), Hyrule::create()->object('name')->string('last')],
+            Hyrule::create(),
+            'rule_name:name.first,name.last',
+        ];
+
+        yield 'pathexp' =>  [
+            'rule_name',
+            [Hyrule::pathExp()->parent()],
+            Hyrule::create()->object('name')->string('first'),
+            'rule_name:name',
+        ];
+
+        yield 'many pathexp' =>  [
+            'rule_name',
+            [Hyrule::pathExp()->parent(), Hyrule::pathExp()->parent()->get('last')],
+            Hyrule::create()->object('name')->string('last')->end()->string('first'),
+            'rule_name:name,name.last',
+        ];
+    }
+}


### PR DESCRIPTION
The code that builds a property rule in a way that respects node or path-expression arguments (e.g. rules that accept fields as arguments e.g. `required_if:field`) was repeated all over the place. This PR consolidates the logic into one spot.