### PR TITLE
feat: declare `NodeType` enum & use it

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         testdox="true"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Nodes/ArrayNode.php
+++ b/src/Nodes/ArrayNode.php
@@ -27,9 +27,9 @@ class ArrayNode extends CompoundNode
 
     /**
      * @param string|NodeType $type
-     * @return AbstractNode
+     * @return ScalarNode|ArrayNode|ObjectNode|FileNode
      */
-    public function each(string|NodeType $type): AbstractNode
+    public function each(NodeType|string $type): AbstractNode
     {
         $className = $this->resolveNodeClassName($type);
         $this->failIfTypeChanged($className);

--- a/src/Nodes/NodeType.php
+++ b/src/Nodes/NodeType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Square\Hyrule\Nodes;
+
+enum NodeType: string
+{
+    case Integer = 'integer';
+    case String = 'string';
+    case Numeric = 'numeric';
+    case Float = 'float';
+    case Boolean = 'boolean';
+    case Array = 'array';
+    case Object = 'object';
+    case Scalar = 'scalar';
+    case File = 'file';
+
+    /**
+     * @return string
+     */
+    public function nodeClassName(): string
+    {
+        return match($this) {
+            self::Integer => IntegerNode::class,
+            self::String => StringNode::class,
+            self::Numeric => NumericNode::class,
+            self::Float => FloatNode::class,
+            self::Boolean => BooleanNode::class,
+            self::Array => ArrayNode::class,
+            self::Object => ObjectNode::class,
+            self::Scalar => ScalarNode::class,
+            self::File => FileNode::class,
+        };
+    }
+}

--- a/tests/ArrayNodeTest.php
+++ b/tests/ArrayNodeTest.php
@@ -153,7 +153,7 @@ class ArrayNodeTest extends NodeTestAbstract
                 [],
             ],
             static function (ArrayNode $node) {
-                $node->each('array')
+                $node->each(NodeType::Array)
                         ->each(NodeType::Integer)->end()
                         ->min(1);
             }
@@ -177,7 +177,7 @@ class ArrayNodeTest extends NodeTestAbstract
     /**
      * @param mixed $type
      * @return void
-     * @dataProvider dataRedefininSameType
+     * @dataProvider dataRedefiningSameType
      */
     public function testRedefiningSameType(mixed $type)
     {
@@ -187,7 +187,7 @@ class ArrayNodeTest extends NodeTestAbstract
         $this->assertSame($original, $redefined);
     }
 
-    public function dataRedefininSameType()
+    public static function dataRedefiningSameType()
     {
         foreach (NodeType::cases() as $nodeType) {
             yield $nodeType->name => [$nodeType];

--- a/tests/BuilderTypedTest.php
+++ b/tests/BuilderTypedTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Square\Hyrule\Hyrule;
 use Square\Hyrule\Nodes\ArrayNode;
 use Square\Hyrule\Nodes\IntegerNode;
+use Square\Hyrule\Nodes\NodeType;
 use Square\Hyrule\Nodes\ObjectNode;
 use Square\Hyrule\Nodes\ScalarNode;
 use Square\Hyrule\Nodes\StringNode;
@@ -104,7 +105,7 @@ class BuilderTypedTest extends TestCase
     {
         $node = new ArrayNode('bar');
         $reference = $node
-            ->each('string')
+            ->each(NodeType::String)
                 ->min(2)
                 ->max(20);
 
@@ -125,7 +126,7 @@ class BuilderTypedTest extends TestCase
         $reference = $node
             ->min(1)
             ->max(20)
-            ->each('object')
+            ->each(NodeType::Object)
                 ->string('name')->required()->max(255)->end()
                 ->integer('age')->nullable()->end()
                 ->boolean('accept')->required()->end();
@@ -150,11 +151,11 @@ class BuilderTypedTest extends TestCase
         $reference = $node
             ->min(1)
             ->max(20)
-            ->each('object')
+            ->each(NodeType::Object)
                 ->string('name')->required()->max(255)->end()
                 ->array('hobbies')
                     ->max(5)
-                    ->each('string')
+                    ->each(NodeType::String)
                         ->uppercase()
                     ->end()
                 ->end();
@@ -200,7 +201,7 @@ class BuilderTypedTest extends TestCase
 
         $builder = $builder
             ->array('areas')
-                ->each('object')
+                ->each(NodeType::Object)
                         ->object('coordinates')
                         ->nullable()
                         ->float('latitude')

--- a/tests/NodeTypeTest.php
+++ b/tests/NodeTypeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Square\Hyrule\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Square\Hyrule\Nodes\AbstractNode;
+use Square\Hyrule\Nodes\NodeType;
+
+class NodeTypeTest extends TestCase
+{
+    public function testAllCasesResolveAbstractNodeTypes()
+    {
+        foreach (NodeType::cases() as $nodeType) {
+            $className = $nodeType->nodeClassName();
+            $this->assertTrue(
+                is_a($className, AbstractNode::class, true),
+                sprintf('Expected (%s)#nodeClassName() to return a class of type %s. Got %s', get_class($nodeType), AbstractNode::class, $className),
+            );
+        }
+    }
+}

--- a/tests/PathExpressionTest.php
+++ b/tests/PathExpressionTest.php
@@ -7,6 +7,7 @@ namespace Square\Hyrule\Tests;
 use PHPUnit\Framework\TestCase;
 use Square\Hyrule\Hyrule;
 use Square\Hyrule\Nodes\ArrayNode;
+use Square\Hyrule\Nodes\NodeType;
 use Square\Hyrule\Nodes\ObjectNode;
 use Square\Hyrule\PathExp;
 use Square\Hyrule\Rules\KnownPropertiesOnly;
@@ -36,13 +37,13 @@ class PathExpressionTest extends TestCase
         $reference = $node
             ->min(1)
             ->max(20)
-            ->each('object')
+            ->each(NodeType::Object)
                 ->string('name')->required()->max(255)->end()
                 ->boolean('cool_kid')->nullable()->end()
                 ->array('hobbies')
                     ->requiredIf(PathExp::new()->parent()->get('cool_kid'), '1')
                     ->max(5)
-                    ->each('string')
+                    ->each(NodeType::String)
                         ->uppercase()
                     ->end()
                 ->end();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+error_reporting(E_ALL & ~E_USER_DEPRECATED);
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Improves `ArrayNode` building by fortifying the `each()` type.